### PR TITLE
Add .travis.yml (+ npm deploy/esdoc publish on tag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+- '6'
+deploy:
+  provider: npm
+  email: christine@honeycomb.io
+  api_key:
+    secure: ob5fIED/4IJ66/3xa2dkuTrsQW2/thIh437Nbt/Jocjpy9BhDf2/OKH17GLTHm6RoaokiAJjBts8rQ1deDcktqFEGnV2AUAtxwhzh5oKHqQh5IXFbHUHGK+jykE96C9K/lDm6N55D/TLWdwbsbbBz4dwUxvnzlGY+VWzY5fo/PB1mTUW7WC2H4vhyv14MNHqB2xZnFWvSnP+xVRNSeZms5KbPakjRfOusP+Sbxwg5OpasVm/ZLDHp/BWkF/qumTepZMUdGom7/JZzHFFdNOuPrEPwk8teFienFcpQgewkXRDecZPLQY5sO8BJoGSfinSzpsqJuDcw8bnmnAJhl07xQFPenyTqY4acerbh8gq/pQnCLjdD278rDwqR5vFWlyWg/Uy9NKVRNR7MjgpI+cV8FoYnipBENcRECJedgtegte4CtxuCtu/PMzCxZqunZj7eBAGJVyYmLNhiAG6mGd4ZLUcs8+IgicFa8uGKC8wx7M5EGr5wjnePTgyuFr5i3Q0tcxAhTnJb2Umwx3SWOfmJa9IXwIzpVTzw87k/E/CkbtQSmuVAgoK5lI1TsT1aGw54Z7wM4l/W/vGIr0PT7bLEH/vYS164J+Pb5BkTPcVzUUjW0LOrOjv6ZNUSYHYZBdWtuw7snHP4zNOArGgnsr5RP0Nde6bga8UMHIGDcdRz/I=
+  on:
+    tags: true
+    repo: honeycombio/dynsampler-js
+after_deploy:
+- curl 'https://doc.esdoc.org/api/create' -X POST --data-urlencode "gitUrl=git@github.com:honeycombio/dynsampler-js.git"


### PR DESCRIPTION
Matches the convention we try to maintain on our various open source SDK repos (e.g. [libhoney-js](https://github.com/honeycombio/libhoney-js/blob/master/.travis.yml), ditto libhoney-py/rb/etc) to push on tagged commits.