### PR TITLE
[ignore this one, too] use Circle CI for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,147 @@
+version: 2.1
+
+# YAML Anchors to reduce copypasta
+
+# This is necessary for job to run when a tag is created
+filters_always: &filters_always
+  filters:
+    tags:
+      only: /.*/
+
+# Restrict running to only be on tags starting with vNNNN
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
+matrix_nodeversions: &matrix_nodeversions
+  matrix:
+    parameters:
+      nodeversion: ["8", "10", "11", "12", "14", "15"]
+
+# Default version of node to use for lint and publishing
+default_nodeversion: &default_nodeversion "12"
+
+executors:
+  node:
+    parameters:
+      nodeversion:
+        type: string
+        default: *default_nodeversion
+    docker:
+      - image: circleci/node:<< parameters.nodeversion >>
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
+
+commands:
+  publish_github:
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Artifacts being published"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+      - run:
+          name: "GHR Draft"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
+jobs:
+  lint:
+    executor:
+      name: node
+      nodeversion: *default_nodeversion
+    steps:
+      - checkout
+      - run: yarn
+      - run: yarn lint
+
+  test:
+    parameters:
+      nodeversion:
+        type: string
+        default: *default_nodeversion
+    executor:
+      name: node
+      nodeversion: "<< parameters.nodeversion >>"
+    steps:
+      - checkout
+      - run: yarn
+      - run: yarn test
+      - run: yarn build
+
+  build_artifacts:
+    executor:
+      name: node
+    steps:
+      - checkout
+      - run: mkdir -p ~/artifacts
+      - run: yarn
+      - run: yarn build
+      - run: cp ./dist/* ~/artifacts/
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
+
+  publish_github:
+    executor: github
+    steps:
+      - publish_github
+
+  publish_npm:
+    executor:
+      name: node
+    steps:
+      - checkout
+      - run:
+          name: store npm auth token
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run: yarn
+      - run: npm publish
+
+workflows:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - lint
+      - test:
+          requires:
+            - lint
+          <<: *matrix_nodeversions
+
+  build:
+    jobs:
+      - lint:
+          <<: *filters_always
+      - test:
+          <<: *filters_always
+          requires:
+            - lint
+          <<: *matrix_nodeversions
+      - build_artifacts:
+          <<: *filters_always
+          requires:
+            - test
+      - publish_github:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_artifacts
+      - publish_npm:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "microbundle --output lib --external all",
     "start": "microbundle watch --output lib --external all",
     "test": "jest",
+    "lint": "prettier --parser flow --write *.{js,jsx}",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "https://github.com/honeycombio/dynsampler.js",
   "author":
     "Christopher Biscardi <chris@christopherbiscardi.com> (@chrisbiscardi)",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "scripts": {
     "build": "microbundle --output lib --external all",
     "start": "microbundle watch --output lib --external all",


### PR DESCRIPTION
Reuses the CI config from honeycombio/libhoney-js.

+ appease a warning from yarn about the SPDX format of the package's license
+ add a lint command